### PR TITLE
fix show 4 column when 3 items

### DIFF
--- a/lib/src/drag_sort_view.dart
+++ b/lib/src/drag_sort_view.dart
@@ -412,7 +412,7 @@ class DragSortViewState extends State<DragSortView>
       _init(context, padding, margin);
     }
 
-    int column = (_itemCount > 3 ? 3 : _itemCount + 1);
+    int column = (_itemCount >= 3 ? 3 : _itemCount + 1);
     int row = ((_itemCount + (_itemCount < 9 ? 1 : 0)) / 3).ceil();
     double realWidth =
         _itemWidth * column + widget.space * (column - 1) + padding.horizontal;


### PR DESCRIPTION
Show 4 column when add 3 items.

![2591654830600_ pic](https://user-images.githubusercontent.com/7303158/172983121-4ebdf3fa-b6c3-42e6-b0d8-2db4411f2108.jpg)

I think this feature hope max column is 3.

![2601654830611_ pic](https://user-images.githubusercontent.com/7303158/172983133-22610056-acb2-4d5e-9590-c49906d6fad0.jpg)

